### PR TITLE
Compost Tower bugfix and optimization

### DIFF
--- a/src/main/java/org/forsteri/ratatouille/content/compost_tower/CompostData.java
+++ b/src/main/java/org/forsteri/ratatouille/content/compost_tower/CompostData.java
@@ -1,8 +1,6 @@
 package org.forsteri.ratatouille.content.compost_tower;
 
 import com.simibubi.create.api.boiler.BoilerHeater;
-import com.simibubi.create.content.fluids.tank.BoilerHeaters;
-import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
 import com.simibubi.create.foundation.recipe.RecipeFinder;
 import com.simibubi.create.foundation.recipe.trie.AbstractVariant;
 import com.simibubi.create.foundation.recipe.trie.RecipeTrie;
@@ -14,14 +12,9 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.util.Mth;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.capability.IFluidHandler;
-import net.minecraftforge.items.ItemHandlerHelper;
-import net.minecraftforge.items.ItemStackHandler;
 import org.forsteri.ratatouille.util.Lang;
 import org.jetbrains.annotations.NotNull;
 
@@ -75,16 +68,12 @@ public class CompostData {
 
         assert controller.getLevel() != null;
 
-        var inputInventory = controller.inputInventory;
-        var fluidHandler = controller.tankInventory;
-
         if (timer > 0) {
             timer -= getProcessingSpeed();
             if (controller.getLevel().isClientSide) return;
 
             if (timer <= 0) {
-                if (!CompostingRecipe.match(controller, lastRecipe)
-                        || !canOutput(inputInventory, fluidHandler)) {
+                if (!CompostingRecipe.match(controller, lastRecipe)) {
                     updateLastRecipe(controller);
                     return;
                 }
@@ -95,22 +84,6 @@ public class CompostData {
         } else  {
             updateLastRecipe(controller);
         }
-    }
-
-    private boolean canOutput(ItemStackHandler outputInventory, IFluidHandler fluidHandler) {
-        for (ItemStack outputStack : lastRecipe.rollResults()) {
-            if (outputStack.isEmpty()) continue;
-            if (!ItemHandlerHelper.insertItemStacked(outputInventory, outputStack, true).isEmpty()) {
-                return false;
-            }
-        }
-        for (FluidStack fluidStack : lastRecipe.getFluidResults()) {
-            if (fluidStack.isEmpty()) continue;
-            if (fluidHandler.fill(fluidStack, IFluidHandler.FluidAction.SIMULATE) < fluidStack.getAmount()) {
-                return false;
-            }
-        }
-        return true;
     }
 
     public boolean evaluate(CompostTowerBlockEntity tower) {
@@ -246,7 +219,7 @@ public class CompostData {
     }
 
     private boolean matchStaticFilters(Recipe<?> recipe) {
-        return true;
+        return recipe instanceof CompostingRecipe;
     }
 
     protected Object getRecipeCacheKey() {

--- a/src/main/java/org/forsteri/ratatouille/content/compost_tower/CompostingRecipe.java
+++ b/src/main/java/org/forsteri/ratatouille/content/compost_tower/CompostingRecipe.java
@@ -2,13 +2,14 @@ package org.forsteri.ratatouille.content.compost_tower;
 
 import com.simibubi.create.content.processing.recipe.ProcessingRecipe;
 import com.simibubi.create.content.processing.recipe.ProcessingRecipeBuilder;
-import com.simibubi.create.foundation.item.ItemHelper;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
-import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.wrapper.RecipeWrapper;
 import org.forsteri.ratatouille.entry.CRRecipeTypes;
 import org.jetbrains.annotations.NotNull;
@@ -58,28 +59,27 @@ public class CompostingRecipe extends ProcessingRecipe<RecipeWrapper> {
     }
 
     public static boolean match(CompostTowerBlockEntity controller, Recipe<?> recipe) {
-        if (!(recipe instanceof CompostingRecipe compostingRecipe)) return false;
+        if (!(recipe instanceof CompostingRecipe compostingRecipe))
+            return false;
 
-        var testInv = new ItemStackHandler(controller.inputInventory.getSlots());
-        ItemHelper.copyContents(controller.inputInventory, testInv);
+        IItemHandler itemHandler = controller.inputInventory;
+        int[] extractedItemsFromSlot = new int[itemHandler.getSlots()];
 
-        for (var itemIngredient: compostingRecipe.getIngredients()) {
+        for (Ingredient itemIngredient: compostingRecipe.getIngredients()) {
             boolean found = false;
-            for (int slot = 0; slot < testInv.getSlots(); slot++) {
-                var stackInSlot = testInv.getStackInSlot(slot);
+            for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
+                ItemStack stackInSlot = itemHandler.getStackInSlot(slot);
+                if (stackInSlot.getCount() <= extractedItemsFromSlot[slot])
+                    continue;
 
-                for (var item: itemIngredient.getItems()) {
-                    if (item.is(stackInSlot.getItem())
-                            && stackInSlot.getCount() >= item.getCount()) {
-                        found = true;
-                        testInv.setStackInSlot(slot, stackInSlot.copyWithCount(
-                                stackInSlot.getCount() - item.getCount()
-                        ));
-                        break;
-                    }
+                if (itemIngredient.test(stackInSlot)) {
+                    extractedItemsFromSlot[slot]++;
+                    found = true;
+                    break;
                 }
             }
-            if (!found) return false;
+            if (!found)
+                return false;
         }
 
         for (var fluidIngredient: compostingRecipe.getFluidIngredients()) {
@@ -95,7 +95,7 @@ public class CompostingRecipe extends ProcessingRecipe<RecipeWrapper> {
             if (!found) return false;
         }
 
-        return true;
+        return compostingRecipe.canOutput(controller.outputInventory, controller.tankInventory);
     }
     public CompostingRecipe(ProcessingRecipeBuilder.ProcessingRecipeParams params) {
         super(CRRecipeTypes.COMPOSTING, params);
@@ -130,5 +130,21 @@ public class CompostingRecipe extends ProcessingRecipe<RecipeWrapper> {
             }
         }
         return false;
+    }
+
+    public boolean canOutput(IItemHandler outputInventory, IFluidHandler fluidHandler) {
+        for (ItemStack outputStack : rollResults()) {
+            if (outputStack.isEmpty()) continue;
+            if (!ItemHandlerHelper.insertItemStacked(outputInventory, outputStack, true).isEmpty()) {
+                return false;
+            }
+        }
+        for (FluidStack fluidStack : getFluidResults()) {
+            if (fluidStack.isEmpty()) continue;
+            if (fluidHandler.fill(fluidStack, IFluidHandler.FluidAction.SIMULATE) < fluidStack.getAmount()) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
修复了堆肥塔两个bug：
1. 在应用配方前、判断输出空间是否足够时，本应判断输出槽，实际却写错为输入槽，导致自定义配方中如果有三种物品原料，那么配方一定会执行失败
2. 根据机械动力本体代码的语义，match方法应该具有两个功能：判断原料是否充足和输出空间是否充足，而后者并未实现

进行了一些性能优化：
1. matchStaticFilter方法不应该始终返回true，至少需要筛选出堆肥配方，否则每次搜索配方都会**在mc存在的所有配方**中搜索
2. match方法中没必要复制整个物品输入，尽管其槽位并不多